### PR TITLE
Bump Vector version from v0.21.2 to v0.24.0.

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,4 +1,4 @@
-FROM timberio/vector:0.21.2-debian as logshipper
+FROM timberio/vector:0.24.0-debian as logshipper
 
 RUN apt update \
     && apt install -y \

--- a/balena.yml
+++ b/balena.yml
@@ -20,4 +20,4 @@ data:
     - surface-go
     - surface-pro-6
     - up-board
-version: 0.2.1
+version: 1.0.0

--- a/templates/sink-vector.yaml.template
+++ b/templates/sink-vector.yaml.template
@@ -10,6 +10,7 @@ sinks:
       max_events: 1000
       type: memory
       when_full: drop_newest
+    compression: true
     healthcheck:
       enabled: true
     keepalive:
@@ -21,4 +22,4 @@ sinks:
       #ca_file: "${CERTIFICATES_DIR}/ca.pem"
       #crt_file: "${CERTIFICATES_DIR}/client.pem"
       #key_file: "${CERTIFICATES_DIR}/client-key.pem"
-    version: "1"
+    version: "2"


### PR DESCRIPTION
Breaking change: Switches to Vector API V2 which is not compatible with V1.

Enables gRPC compression with gzip.

Change-type: major
Signed-off-by: Carlo Miguel F. Cruz <carloc@balena.io>