### PR TITLE
Adds an option to use a disk buffer for Vector sink.

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,16 +71,19 @@ sinks:
 
 `bh.cr/balenablocks/logshipper` can be configured via the following variables:
 
-| Environment Variable          | Default | Description                                              |
-| ----------------------------- | ------- | -------------------------------------------------------  |
-| `DISABLE`                     | `false` | Disables the logshipper service                          |
-| `VECTOR_COMPRESSION_ENABLED`  | `true`  | Enables gRPC compression with gzip                       |
-| `VECTOR_ENDPOINT`             | ``      | The endpoint of the vector log aggregator                |
-| `VECTOR_REQUEST_TIMEOUT_SECS` | `300`   | The maximum time a request can take before being aborted |
-| `VECTOR_TLS_CA_FILE`          | ``      | An additional CA certificate file encoded in base 64     |
-| `VECTOR_TLS_CRT_FILE`         | ``      | The client certificate file encoded in base 64           |
-| `VECTOR_TLS_KEY_FILE`         | ``      | The client certificate key file encoded in base 64       |
-| `VECTOR_VERIFY_CERTIFICATE`   | `false` | Enables TLS certificate verification.                    |
+| Environment Variable          | Default  | Description                                               |
+| ----------------------------- | -------- | --------------------------------------------------------- |
+| `DISABLE`                     | `false`  | Disables the logshipper service                           |
+| `VECTOR_BUFFER_MAX_EVENTS`    | `1000`   | The maximum number of events allowed in the buffer        |
+| `VECTOR_BUFFER_MAX_SIZE`      | `268435488` | The maximum size of the buffer on the disk             |
+| `VECTOR_BUFFER_TYPE`          | `memory` | The type of buffer to use                                 |
+| `VECTOR_COMPRESSION_ENABLED`  | `true`   | Enables gRPC compression with gzip                        |
+| `VECTOR_ENDPOINT`             | ``       | The endpoint of the vector log aggregator                 |
+| `VECTOR_REQUEST_TIMEOUT_SECS` | `300`    | The maximum time a request can take before being aborted  |
+| `VECTOR_TLS_CA_FILE`          | ``       | An additional CA certificate file encoded in base 64      |
+| `VECTOR_TLS_CRT_FILE`         | ``       | The client certificate file encoded in base 64            |
+| `VECTOR_TLS_KEY_FILE`         | ``       | The client certificate key file encoded in base 64        |
+| `VECTOR_VERIFY_CERTIFICATE`   | `false`  | Enables TLS certificate verification.                     |
 
 You can refer to the [docs](https://www.balena.io/docs/learn/manage/serv-vars/#environment-and-service-variables) on how to set environment or service variables
 

--- a/balena.yml
+++ b/balena.yml
@@ -20,4 +20,4 @@ data:
     - surface-go
     - surface-pro-6
     - up-board
-version: 1.2.0
+version: 1.2.1

--- a/templates/sinks/sink-vector.yaml.template
+++ b/templates/sinks/sink-vector.yaml.template
@@ -8,17 +8,18 @@ batch:
   max_events: 500
   max_size: 1000000
 buffer:
-  max_events: 1000
-  type: memory
+  #max_events: ${VECTOR_BUFFER_MAX_EVENTS:-1000}
+  #max_size: ${VECTOR_BUFFER_MAX_SIZE:-268435488}
+  type: ${VECTOR_BUFFER_TYPE:-memory}
   when_full: drop_newest
-compression: ${VECTOR_COMPRESSION_ENABLED}
+compression: ${VECTOR_COMPRESSION_ENABLED:-true}
 healthcheck:
   enabled: true
 request:
   concurrency: 1024
-  timeout_secs: 300
+  timeout_secs: ${VECTOR_REQUEST_TIMEOUT_SECS:-300}
 tls:
-  enabled: ${VECTOR_TLS_ENABLED}
+  enabled: ${VECTOR_TLS_ENABLED:-false}
   #verify_certificate: ${VECTOR_TLS_ENABLED}
   #verify_hostname: ${VECTOR_TLS_ENABLED}
   #ca_file: "${CERTIFICATES_DIR}/ca.pem"


### PR DESCRIPTION
This allows users to use a disk buffer for environments that not prone to disk failure caused by frequent writes to disk.

Change-type: patch
Signed-off-by: Carlo Miguel F. Cruz <carloc@balena.io>