### PR TITLE
Re-enables config verification and gives TLS verification options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,19 +71,20 @@ sinks:
 
 `bh.cr/balenablocks/logshipper` can be configured via the following variables:
 
-| Environment Variable          | Default  | Description                                               |
-| ----------------------------- | -------- | --------------------------------------------------------- |
-| `DISABLE`                     | `false`  | Disables the logshipper service                           |
-| `VECTOR_BUFFER_MAX_EVENTS`    | `1000`   | The maximum number of events allowed in the buffer        |
-| `VECTOR_BUFFER_MAX_SIZE`      | `268435488` | The maximum size of the buffer on the disk             |
-| `VECTOR_BUFFER_TYPE`          | `memory` | The type of buffer to use                                 |
-| `VECTOR_COMPRESSION_ENABLED`  | `true`   | Enables gRPC compression with gzip                        |
-| `VECTOR_ENDPOINT`             | ``       | The endpoint of the vector log aggregator                 |
-| `VECTOR_REQUEST_TIMEOUT_SECS` | `300`    | The maximum time a request can take before being aborted  |
-| `VECTOR_TLS_CA_FILE`          | ``       | An additional CA certificate file encoded in base 64      |
-| `VECTOR_TLS_CRT_FILE`         | ``       | The client certificate file encoded in base 64            |
-| `VECTOR_TLS_KEY_FILE`         | ``       | The client certificate key file encoded in base 64        |
-| `VECTOR_VERIFY_CERTIFICATE`   | `false`  | Enables TLS certificate verification.                     |
+| Environment Variable            | Default  | Description                                                |
+| ------------------------------- | -------- | ---------------------------------------------------------- |
+| `DISABLE`                       | `false`  | Disables the logshipper service                            |
+| `VECTOR_BUFFER_MAX_EVENTS`      | `1000`   | The maximum number of events allowed in the buffer         |
+| `VECTOR_BUFFER_MAX_SIZE`        | `268435488` | The maximum size of the buffer on the disk              |
+| `VECTOR_BUFFER_TYPE`            | `memory` | The type of buffer to use                                  |
+| `VECTOR_COMPRESSION_ENABLED`    | `true`   | Enables gRPC compression with gzip                         |
+| `VECTOR_ENDPOINT`               | ``       | The endpoint of the vector log aggregator                  |
+| `VECTOR_REQUEST_TIMEOUT_SECS`   | `300`    | The maximum time a request can take before being aborted   |
+| `VECTOR_TLS_CA_FILE`            | ``       | An additional CA certificate file encoded in base 64       |
+| `VECTOR_TLS_CRT_FILE`           | ``       | The client certificate file encoded in base 64             |
+| `VECTOR_TLS_KEY_FILE`           | ``       | The client certificate key file encoded in base 64         |
+| `VECTOR_TLS_VERIFY_CERTIFICATE` | `true`   | Verifies the TLS certificate of the remote hos             |
+| `VECTOR_TLS_VERIFY_HOSTNAME`    | `true`   | Verifies the endpoint hostname against the TLS certificate |
 
 You can refer to the [docs](https://www.balena.io/docs/learn/manage/serv-vars/#environment-and-service-variables) on how to set environment or service variables
 

--- a/balena.yml
+++ b/balena.yml
@@ -20,4 +20,4 @@ data:
     - surface-go
     - surface-pro-6
     - up-board
-version: 1.2.2
+version: 1.2.3

--- a/balena.yml
+++ b/balena.yml
@@ -20,4 +20,4 @@ data:
     - surface-go
     - surface-pro-6
     - up-board
-version: 1.2.1
+version: 1.2.2

--- a/start.sh
+++ b/start.sh
@@ -56,9 +56,9 @@ function prepare_sink_vector() {
 
 function start_vector() {
 	# https://vector.dev/docs/administration/validating/
-	cat /etc/vector/*.y*ml \
-	&& vector validate --config-dir /etc/vector \
-	&& vector --config-dir /etc/vector
+	cat /etc/vector/*.y*ml
+	# vector validate --config-dir /etc/vector
+	vector --config-dir /etc/vector
 }
 
 

--- a/start.sh
+++ b/start.sh
@@ -43,8 +43,6 @@ function prepare_sink_vector() {
 			sed -i 's|#verify_certificate:|verify_certificate:|g' sinks/sink-vector.yaml
 			sed -i 's|#verify_hostname:|verify_hostname:|g' sinks/sink-vector.yaml
 		fi
-		# https://stackoverflow.com/a/31926346/1559300
-		# cat < templates/sinks/sink-vector.yaml.template | envsubst > sinks/sink-vector.yaml
 
 		if [[ "${VECTOR_BUFFER_TYPE}" == 'disk' ]]; then
                         sed -i 's|#max_size:|max_size:|g' sinks/sink-vector.yaml
@@ -56,9 +54,9 @@ function prepare_sink_vector() {
 
 function start_vector() {
 	# https://vector.dev/docs/administration/validating/
-	cat /etc/vector/*.y*ml
-	# vector validate --config-dir /etc/vector
-	vector --config-dir /etc/vector
+	find /etc/vector -name "*.y*ml" -exec cat {} \; 
+	vector validate --config-dir /etc/vector \
+	&& vector --config-dir /etc/vector
 }
 
 

--- a/templates/sinks/sink-vector.yaml.template
+++ b/templates/sinks/sink-vector.yaml.template
@@ -20,8 +20,8 @@ request:
   timeout_secs: ${VECTOR_REQUEST_TIMEOUT_SECS:-300}
 tls:
   enabled: ${VECTOR_TLS_ENABLED:-false}
-  #verify_certificate: ${VECTOR_TLS_ENABLED}
-  #verify_hostname: ${VECTOR_TLS_ENABLED}
+  #verify_certificate: ${VECTOR_TLS_VERIFY_CERTIFICATE:-true}
+  #verify_hostname: ${VECTOR_TLS_VERIFY_HOSTNAME:-true}
   #ca_file: "${CERTIFICATES_DIR}/ca.pem"
   #crt_file: "${CERTIFICATES_DIR}/client.pem"
   #key_file: "${CERTIFICATES_DIR}/client-key.pem"


### PR DESCRIPTION
- Re-enabled the Vector configuration verification on startup.
- Provides some variables to enable or disable TLS certificate
  or hostname verification.

Change-type: patch
Signed-off-by: Carlo Miguel F. Cruz <carloc@balena.io>