### PR TITLE
Switches buffer behavior to block by default in Kuberentes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ sinks:
 | `VECTOR_BUFFER_MAX_EVENTS`      | `1000`   | The maximum number of events allowed in the buffer         |
 | `VECTOR_BUFFER_MAX_SIZE`        | `268435488` | The maximum size of the buffer on the disk              |
 | `VECTOR_BUFFER_TYPE`            | `memory` | The type of buffer to use                                  |
+| `VECTOR_BUFFER_WHEN_FULL`       | `drop_newest` | The behavior when the buffer becomes full.            |
 | `VECTOR_COMPRESSION_ENABLED`    | `true`   | Enables gRPC compression with gzip                         |
 | `VECTOR_ENDPOINT`               | ``       | The endpoint of the vector log aggregator                  |
 | `VECTOR_REQUEST_TIMEOUT_SECS`   | `300`    | The maximum time a request can take before being aborted   |

--- a/balena.yml
+++ b/balena.yml
@@ -20,4 +20,4 @@ data:
     - surface-go
     - surface-pro-6
     - up-board
-version: 1.2.3
+version: 1.2.4

--- a/start.sh
+++ b/start.sh
@@ -16,6 +16,7 @@ function prepare_source_kubernetes() {
 	if [ -n "$KUBERNETES_SERVICE_HOST" ]
 	then
 		VECTOR_BUFFER_TYPE=${VECTOR_BUFFER_TYPE:-disk}
+		VECTOR_BUFFER_WHEN_FULL=${VECTOR_BUFFER_WHEN_FULL:-block}
 		mkdir -p sources
 		cp -f templates/sources/source-kubernetes.yaml.template sources/source-kubernetes.yaml
 	fi

--- a/templates/sinks/sink-vector.yaml.template
+++ b/templates/sinks/sink-vector.yaml.template
@@ -11,7 +11,7 @@ buffer:
   #max_events: ${VECTOR_BUFFER_MAX_EVENTS:-1000}
   #max_size: ${VECTOR_BUFFER_MAX_SIZE:-268435488}
   type: ${VECTOR_BUFFER_TYPE:-memory}
-  when_full: drop_newest
+  when_full: ${VECTOR_BUFFER_WHEN_FULL:-drop_newest}
 compression: ${VECTOR_COMPRESSION_ENABLED:-true}
 healthcheck:
   enabled: true


### PR DESCRIPTION
Kubernetes typically have a higher volume of events than
a balena device but also use more powerful devices that
can provide larger buffers.  The behavior can still be
overriden by using the VECTOR_BUFFER_WHEN_FULL environment
variable.

Change-type: patch
Signed-off-by: Carlo Miguel F. Cruz <carloc@balena.io>